### PR TITLE
Login review

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
   },
   plugins: [
     'react',
+    'react-hooks',
   ],
   rules: {
     indent: ['error', 2],
@@ -51,5 +52,6 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'react/prop-types': 'off',
     'linebreak-style': 'off',
+    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
   },
 };

--- a/fixtures/accessToken.js
+++ b/fixtures/accessToken.js
@@ -1,0 +1,3 @@
+const accessToken = 'TOKEN';
+
+export default accessToken;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,3 @@
 import '@testing-library/jest-dom';
+
+import 'given2/setup';

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,5 @@
 import '@testing-library/jest-dom';
 
 import 'given2/setup';
+
+import 'jest-localstorage-mock';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7977,6 +7977,12 @@
         }
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.8.tgz",
+      "integrity": "sha512-2FVxM00B0hQsaMPn67Z0TQ+q1jQ5814FpRPvz4Sv8OJhI6M4NIq7FrYP/TA1PtGIzVoC1UGBHc41L2oOWTNnbw==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-react-hooks": "^2.5.1",
     "given2": "^2.1.7",
     "jest": "^26.0.1",
+    "jest-localstorage-mock": "^2.4.8",
     "jest-plugin-context": "^2.9.0",
     "puppeteer": "^5.0.0",
     "redux-mock-store": "^1.5.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import {
   Link,
 } from 'react-router-dom';
 
+import { useDispatch } from 'react-redux';
+
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import LoginPage from './LoginPage';
@@ -13,7 +15,18 @@ import RestaurantsPage from './RestaurantsPage';
 import RestaurantPage from './RestaurantPage';
 import NotFoundPage from './NotFoundPage';
 
+import { setAccessToken } from './actions';
+
+import { loadItem } from './services/storage';
+
 export default function App() {
+  const dispatch = useDispatch();
+
+  const accessToken = loadItem('accessToken');
+  if (accessToken) {
+    dispatch(setAccessToken(accessToken));
+  }
+
   return (
     <div>
       <header>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import {
 
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
+import LoginPage from './LoginPage';
 import RestaurantsPage from './RestaurantsPage';
 import RestaurantPage from './RestaurantPage';
 import NotFoundPage from './NotFoundPage';
@@ -23,6 +24,7 @@ export default function App() {
       <Switch>
         <Route exact path="/" component={HomePage} />
         <Route path="/about" component={AboutPage} />
+        <Route path="/login" component={LoginPage} />
         <Route exact path="/restaurants" component={RestaurantsPage} />
         <Route path="/restaurants/:id" component={RestaurantPage} />
         <Route component={NotFoundPage} />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -70,6 +70,14 @@ describe('App', () => {
     });
   });
 
+  context('with path /login', () => {
+    it('renders the login page', () => {
+      const { container } = renderApp({ path: '/login' });
+
+      expect(container).toHaveTextContent('Login');
+    });
+  });
+
   context('with invalid path', () => {
     it('renders the not found page', () => {
       const { container } = renderApp({ path: '/xxx' });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -27,6 +27,10 @@ describe('App', () => {
       categories: [],
       restaurants: [],
       restaurant: { id: 1, name: '마녀주방' },
+      loginFields: {
+        email: '',
+        password: '',
+      },
     }));
   });
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -29,7 +29,27 @@ describe('App', () => {
       ],
       categories: [],
       restaurants: [],
-      restaurant: { id: 1, name: '마녀주방' },
+      restaurant: {
+        id: 1,
+        name: '마녀주방',
+        address: '서울시 강남구',
+        reviews: [
+          {
+            id: 1,
+            restaurantId: 1,
+            name: '테스터',
+            score: 5,
+            description: '훌륭하다 훌륭하다 지구인놈들',
+          },
+          {
+            id: 3,
+            restaurantId: 1,
+            name: '테스터',
+            score: 3,
+            description: 'Hi!',
+          },
+        ],
+      },
       loginFields: {
         email: '',
         password: '',

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -33,22 +33,7 @@ describe('App', () => {
         id: 1,
         name: '마녀주방',
         address: '서울시 강남구',
-        reviews: [
-          {
-            id: 1,
-            restaurantId: 1,
-            name: '테스터',
-            score: 5,
-            description: '훌륭하다 훌륭하다 지구인놈들',
-          },
-          {
-            id: 3,
-            restaurantId: 1,
-            name: '테스터',
-            score: 3,
-            description: 'Hi!',
-          },
-        ],
+        reviews: [],
       },
       loginFields: {
         email: '',

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -8,9 +8,12 @@ import { render } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
+import { loadItem } from './services/storage';
+
 import App from './App';
 
 jest.mock('react-redux');
+jest.mock('./services/storage');
 
 describe('App', () => {
   const dispatch = jest.fn();
@@ -35,6 +38,7 @@ describe('App', () => {
         score: '',
         description: '',
       },
+      acessToken: given.accessToken,
     }));
   });
 
@@ -91,6 +95,39 @@ describe('App', () => {
       const { container } = renderApp({ path: '/xxx' });
 
       expect(container).toHaveTextContent('Not Found');
+    });
+  });
+
+  context('when logged in', () => {
+    beforeEach(() => {
+      loadItem.mockClear();
+
+      loadItem.mockImplementation(() => 'TOKEN');
+    });
+
+    it('calls dispatch with "setAccessToken"', () => {
+      renderApp({ path: '/' });
+
+      expect(dispatch).toBeCalledWith({
+        type: 'setAccessToken',
+        payload: {
+          accessToken: 'TOKEN',
+        },
+      });
+    });
+  });
+
+  context('when logged out', () => {
+    beforeEach(() => {
+      loadItem.mockClear();
+
+      loadItem.mockImplementation(() => null);
+    });
+
+    it('does not call dispatch', () => {
+      renderApp({ path: '/' });
+
+      expect(dispatch).not.toBeCalled();
     });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -74,7 +74,7 @@ describe('App', () => {
     it('renders the login page', () => {
       const { container } = renderApp({ path: '/login' });
 
-      expect(container).toHaveTextContent('Login');
+      expect(container).toHaveTextContent('Log In');
     });
   });
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -31,6 +31,10 @@ describe('App', () => {
         email: '',
         password: '',
       },
+      reviewFields: {
+        score: '',
+        description: '',
+      },
     }));
   });
 

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -8,6 +8,7 @@ export default function HomePage() {
       <h2>Home</h2>
       <ul>
         <li><Link to="/about">About</Link></li>
+        <li><Link to="/login">Login</Link></li>
         <li><Link to="/restaurants">Restaurants</Link></li>
       </ul>
     </div>

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react';
 import HomePage from './HomePage';
 
 describe('HomePage', () => {
-  const links = ['About', 'Restaurants'];
+  const links = ['About', 'Restaurants', 'Login'];
 
   const renderHomePage = () => render(
     <MemoryRouter>

--- a/src/InputField.jsx
+++ b/src/InputField.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function InputField({
+  label, type, name, value, onChange,
+}) {
+  const id = `input-${name}`;
+
+  function handleChange(event) {
+    const { target: { name: targetName, value: targetValue } } = event;
+    onChange({ name: targetName, value: targetValue });
+  }
+
+  return (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <input
+        type={type}
+        id={id}
+        name={name}
+        value={value}
+        onChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/InputField.test.jsx
+++ b/src/InputField.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import InputField from './InputField';
+
+describe('TextField', () => {
+  const handleChange = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+  });
+
+  it('renders label and input control', () => {
+    const { queryByLabelText } = render((
+      <InputField
+        label="Email"
+        type="email"
+        name="email"
+        value=""
+        onChange={handleChange}
+      />
+    ));
+
+    expect(queryByLabelText('Email')).not.toBeNull();
+  });
+
+  it('listens to input change events', () => {
+    const name = 'email';
+    const value = 'test@test.com';
+
+    const { getByLabelText } = render((
+      <InputField
+        label="Email"
+        type="email"
+        name={name}
+        value=""
+        onChange={handleChange}
+      />
+    ));
+
+    fireEvent.change(getByLabelText('Email'), {
+      target: { name, value },
+    });
+
+    expect(handleChange).toBeCalledWith({ name, value });
+  });
+});

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function LoginForm({ onClick }) {
+  return (
+    <>
+      <div>
+        <label htmlFor="login-email">Email</label>
+        <input type="email" id="login-email" />
+      </div>
+      <div>
+        <label htmlFor="login-password">Password</label>
+        <input type="password" id="login-password" />
+      </div>
+      <button
+        type="button"
+        onClick={onClick}
+      >
+        Log In
+      </button>
+    </>
+  );
+}

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
 
-export default function LoginForm({ onClick }) {
+export default function LoginForm({ onChange, onClick }) {
   return (
     <>
       <div>
         <label htmlFor="login-email">Email</label>
-        <input type="email" id="login-email" />
+        <input
+          type="email"
+          id="login-email"
+          onChange={onChange}
+        />
       </div>
       <div>
         <label htmlFor="login-password">Password</label>
-        <input type="password" id="login-password" />
+        <input
+          type="password"
+          id="login-password"
+          onChange={onChange}
+        />
       </div>
       <button
         type="button"

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-export default function LoginForm({ field, onChange, onClick }) {
-  const { email, password } = field;
+export default function LoginForm({ fields, onChange, onClick }) {
+  const { email, password } = fields;
 
   function handleChange(event) {
     const { target: { name, value } } = event;

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -15,6 +15,7 @@ export default function LoginForm({ field, onChange, onClick }) {
         <input
           type="email"
           id="login-email"
+          name="email"
           value={email}
           onChange={handleChange}
         />
@@ -24,6 +25,7 @@ export default function LoginForm({ field, onChange, onClick }) {
         <input
           type="password"
           id="login-password"
+          name="password"
           value={password}
           onChange={handleChange}
         />

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,35 +1,26 @@
 import React from 'react';
 
+import InputField from './InputField';
+
 export default function LoginForm({ fields, onChange, onClick }) {
   const { email, password } = fields;
 
-  function handleChange(event) {
-    const { target: { name, value } } = event;
-    onChange({ name, value });
-  }
-
   return (
     <>
-      <div>
-        <label htmlFor="login-email">Email</label>
-        <input
-          type="email"
-          id="login-email"
-          name="email"
-          value={email}
-          onChange={handleChange}
-        />
-      </div>
-      <div>
-        <label htmlFor="login-password">Password</label>
-        <input
-          type="password"
-          id="login-password"
-          name="password"
-          value={password}
-          onChange={handleChange}
-        />
-      </div>
+      <InputField
+        label="Email"
+        type="email"
+        name="email"
+        value={email}
+        onChange={onChange}
+      />
+      <InputField
+        label="Password"
+        type="password"
+        name="password"
+        value={password}
+        onChange={onChange}
+      />
       <button
         type="button"
         onClick={onClick}

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-export default function LoginForm({ onChange, onClick }) {
+export default function LoginForm({ field, onChange, onClick }) {
+  const { email, password } = field;
+
+  function handleChange(event) {
+    const { target: { name, value } } = event;
+    onChange({ name, value });
+  }
+
   return (
     <>
       <div>
@@ -8,7 +15,8 @@ export default function LoginForm({ onChange, onClick }) {
         <input
           type="email"
           id="login-email"
-          onChange={onChange}
+          value={email}
+          onChange={handleChange}
         />
       </div>
       <div>
@@ -16,7 +24,8 @@ export default function LoginForm({ onChange, onClick }) {
         <input
           type="password"
           id="login-password"
-          onChange={onChange}
+          value={password}
+          onChange={handleChange}
         />
       </div>
       <button

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import LoginForm from './LoginForm';
+
+describe('LoginForm', () => {
+  it('renders login form', () => {
+    const handleClick = jest.fn();
+
+    const { getByLabelText, getByText } = render((
+      <LoginForm
+        onClick={handleClick}
+      />
+    ));
+
+    expect(getByLabelText('Email')).not.toBeNull();
+    expect(getByLabelText('Password')).not.toBeNull();
+
+    fireEvent.click(getByText('Log In'));
+
+    expect(handleClick).toBeCalled();
+  });
+});

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -36,19 +36,31 @@ describe('LoginForm', () => {
 
   it('listens to input change events', () => {
     const controls = [
-      { label: 'Email', origin: '', value: 'test@test.com' },
-      { label: 'Password', origin: '', value: 'test' },
+      {
+        label: 'Email',
+        name: 'email',
+        origin: '',
+        value: 'test@test.com',
+      },
+      {
+        label: 'Password',
+        name: 'password',
+        origin: '',
+        value: 'test',
+      },
     ];
     const { getByLabelText } = renderLoginForm({ email: '', password: '' });
 
-    controls.forEach(({ label, origin, value }) => {
+    controls.forEach(({
+      label, name, origin, value,
+    }) => {
       expect(getByLabelText(label).value).toBe(origin);
 
       fireEvent.change(getByLabelText(label), {
         target: { value },
       });
 
-      expect(handleChange).toBeCalled();
+      expect(handleChange).toBeCalledWith({ name, value });
     });
   });
 });

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -5,14 +5,25 @@ import { render, fireEvent } from '@testing-library/react';
 import LoginForm from './LoginForm';
 
 describe('LoginForm', () => {
-  it('renders login form', () => {
-    const handleClick = jest.fn();
+  const handleChange = jest.fn();
+  const handleClick = jest.fn();
 
-    const { getByLabelText, getByText } = render((
+  beforeEach(() => {
+    handleChange.mockClear();
+    handleClick.mockClear();
+  });
+
+  function renderLoginForm() {
+    return render((
       <LoginForm
+        onChange={handleChange}
         onClick={handleClick}
       />
     ));
+  }
+
+  it('renders login form', () => {
+    const { getByLabelText, getByText } = renderLoginForm();
 
     expect(getByLabelText('Email')).not.toBeNull();
     expect(getByLabelText('Password')).not.toBeNull();
@@ -20,5 +31,15 @@ describe('LoginForm', () => {
     fireEvent.click(getByText('Log In'));
 
     expect(handleClick).toBeCalled();
+  });
+
+  it('listens to input change events', () => {
+    const { getByLabelText } = renderLoginForm();
+
+    fireEvent.change(getByLabelText('Email'), {
+      target: { value: 'test@test.com' },
+    });
+
+    expect(handleChange).toBeCalled();
   });
 });

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -57,7 +57,7 @@ describe('LoginForm', () => {
       expect(getByLabelText(label).value).toBe(origin);
 
       fireEvent.change(getByLabelText(label), {
-        target: { value },
+        target: { name, value },
       });
 
       expect(handleChange).toBeCalledWith({ name, value });

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -24,10 +24,10 @@ describe('LoginForm', () => {
   }
 
   it('renders login form', () => {
-    const { getByLabelText, getByText } = renderLoginForm({});
+    const { getByLabelText: queryByLabelText, getByText } = renderLoginForm({});
 
-    expect(getByLabelText('Email')).not.toBeNull();
-    expect(getByLabelText('Password')).not.toBeNull();
+    expect(queryByLabelText('Email')).not.toBeNull();
+    expect(queryByLabelText('Password')).not.toBeNull();
 
     fireEvent.click(getByText('Log In'));
 

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -24,7 +24,7 @@ describe('LoginForm', () => {
   }
 
   it('renders login form', () => {
-    const { getByLabelText: queryByLabelText, getByText } = renderLoginForm({});
+    const { queryByLabelText, getByText } = renderLoginForm({});
 
     expect(queryByLabelText('Email')).not.toBeNull();
     expect(queryByLabelText('Password')).not.toBeNull();

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -16,7 +16,7 @@ describe('LoginForm', () => {
   function renderLoginForm({ email, password }) {
     return render((
       <LoginForm
-        field={{ email, password }}
+        fields={{ email, password }}
         onChange={handleChange}
         onClick={handleClick}
       />

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -13,9 +13,10 @@ describe('LoginForm', () => {
     handleClick.mockClear();
   });
 
-  function renderLoginForm() {
+  function renderLoginForm({ email, password }) {
     return render((
       <LoginForm
+        field={{ email, password }}
         onChange={handleChange}
         onClick={handleClick}
       />
@@ -23,7 +24,7 @@ describe('LoginForm', () => {
   }
 
   it('renders login form', () => {
-    const { getByLabelText, getByText } = renderLoginForm();
+    const { getByLabelText, getByText } = renderLoginForm({});
 
     expect(getByLabelText('Email')).not.toBeNull();
     expect(getByLabelText('Password')).not.toBeNull();
@@ -34,12 +35,20 @@ describe('LoginForm', () => {
   });
 
   it('listens to input change events', () => {
-    const { getByLabelText } = renderLoginForm();
+    const controls = [
+      { label: 'Email', origin: '', value: 'test@test.com' },
+      { label: 'Password', origin: '', value: 'test' },
+    ];
+    const { getByLabelText } = renderLoginForm({ email: '', password: '' });
 
-    fireEvent.change(getByLabelText('Email'), {
-      target: { value: 'test@test.com' },
+    controls.forEach(({ label, origin, value }) => {
+      expect(getByLabelText(label).value).toBe(origin);
+
+      fireEvent.change(getByLabelText(label), {
+        target: { value },
+      });
+
+      expect(handleChange).toBeCalled();
     });
-
-    expect(handleChange).toBeCalled();
   });
 });

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -7,9 +7,21 @@ import LoginForm from './LoginForm';
 import {
   changeLoginField,
   requestLogin,
+  requestLogout,
 } from './actions';
 
 import { get } from './utils';
+
+function LogoutButton({ onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+    >
+      Log out
+    </button>
+  );
+}
 
 export default function LoginFormContainer() {
   const dispatch = useDispatch();
@@ -18,8 +30,12 @@ export default function LoginFormContainer() {
     dispatch(changeLoginField({ name, value }));
   }
 
-  function handleClick() {
+  function handleClickLogin() {
     dispatch(requestLogin());
+  }
+
+  function handleClickLogout() {
+    dispatch(requestLogout());
   }
 
   const { email, password } = useSelector(get('loginFields'));
@@ -27,12 +43,19 @@ export default function LoginFormContainer() {
 
   return (
     <>
-      <LoginForm
-        fields={{ email, password }}
-        onChange={handleChange}
-        onClick={handleClick}
-      />
-      { accessToken ? <p>로그인 되었습니다.</p> : <p>로그인 해주세요.</p>}
+      { accessToken
+        ? (
+          <LogoutButton
+            onClick={handleClickLogout}
+          />
+        )
+        : (
+          <LoginForm
+            fields={{ email, password }}
+            onChange={handleChange}
+            onClick={handleClickLogin}
+          />
+        )}
     </>
   );
 }

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -7,7 +7,7 @@ import LoginForm from './LoginForm';
 import {
   changeLoginField,
   requestLogin,
-  requestLogout,
+  setAccessToken,
 } from './actions';
 
 import { get } from './utils';
@@ -35,7 +35,7 @@ export default function LoginFormContainer() {
   }
 
   function handleClickLogout() {
-    dispatch(requestLogout());
+    dispatch(setAccessToken(''));
   }
 
   const { email, password } = useSelector(get('loginFields'));

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function LoginFormContainer() {
+  return (
+    <>
+      <div>
+        <label htmlFor="login-email">Email</label>
+        <input type="email" id="login-email" />
+      </div>
+      <div>
+        <label htmlFor="login-password">Password</label>
+        <input type="password" id="login-password" />
+      </div>
+    </>
+  );
+}

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -26,7 +26,7 @@ export default function LoginFormContainer() {
 
   return (
     <LoginForm
-      field={{ email, password }}
+      fields={{ email, password }}
       onChange={handleChange}
       onClick={handleClick}
     />

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -1,22 +1,33 @@
 import React from 'react';
 
-import { useDispatch } from 'react-redux';
-
-import {
-  requestLogin,
-} from './actions';
+import { useDispatch, useSelector } from 'react-redux';
 
 import LoginForm from './LoginForm';
 
+import {
+  changeLoginField,
+  requestLogin,
+} from './actions';
+
+import { get } from './utils';
+
 export default function LoginFormContainer() {
   const dispatch = useDispatch();
+
+  function handleChange({ name, value }) {
+    dispatch(changeLoginField({ name, value }));
+  }
 
   function handleClick() {
     dispatch(requestLogin());
   }
 
+  const { email, password } = useSelector(get('loginFields'));
+
   return (
     <LoginForm
+      field={{ email, password }}
+      onChange={handleChange}
       onClick={handleClick}
     />
   );

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -6,6 +6,8 @@ import {
   requestLogin,
 } from './actions';
 
+import LoginForm from './LoginForm';
+
 export default function LoginFormContainer() {
   const dispatch = useDispatch();
 
@@ -14,21 +16,8 @@ export default function LoginFormContainer() {
   }
 
   return (
-    <>
-      <div>
-        <label htmlFor="login-email">Email</label>
-        <input type="email" id="login-email" />
-      </div>
-      <div>
-        <label htmlFor="login-password">Password</label>
-        <input type="password" id="login-password" />
-      </div>
-      <button
-        type="button"
-        onClick={handleClick}
-      >
-        Log In
-      </button>
-    </>
+    <LoginForm
+      onClick={handleClick}
+    />
   );
 }

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -23,12 +23,16 @@ export default function LoginFormContainer() {
   }
 
   const { email, password } = useSelector(get('loginFields'));
+  const accessToken = useSelector(get('accessToken'));
 
   return (
-    <LoginForm
-      fields={{ email, password }}
-      onChange={handleChange}
-      onClick={handleClick}
-    />
+    <>
+      <LoginForm
+        fields={{ email, password }}
+        onChange={handleChange}
+        onClick={handleClick}
+      />
+      { accessToken ? <p>로그인 되었습니다.</p> : <p>로그인 해주세요.</p>}
+    </>
   );
 }

--- a/src/LoginFormContainer.jsx
+++ b/src/LoginFormContainer.jsx
@@ -1,6 +1,18 @@
 import React from 'react';
 
+import { useDispatch } from 'react-redux';
+
+import {
+  requestLogin,
+} from './actions';
+
 export default function LoginFormContainer() {
+  const dispatch = useDispatch();
+
+  function handleClick() {
+    dispatch(requestLogin());
+  }
+
   return (
     <>
       <div>
@@ -11,6 +23,12 @@ export default function LoginFormContainer() {
         <label htmlFor="login-password">Password</label>
         <input type="password" id="login-password" />
       </div>
+      <button
+        type="button"
+        onClick={handleClick}
+      >
+        Log In
+      </button>
     </>
   );
 }

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import LoginFormContainer from './LoginFormContainer';
+
+describe('LoginFormContainer', () => {
+  it('renders login form', () => {
+    const { getByLabelText } = render(<LoginFormContainer />);
+
+    expect(getByLabelText('Email')).not.toBeNull();
+    expect(getByLabelText('Password')).not.toBeNull();
+  });
+});

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, fireEvent } from '@testing-library/react';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import LoginFormContainer from './LoginFormContainer';
 
@@ -15,10 +15,21 @@ describe('LoginFormContainer', () => {
     dispatch.mockClear();
 
     useDispatch.mockImplementation(() => dispatch);
+
+    useSelector.mockImplementation((selector) => selector({
+      loginFields: {
+        email: '',
+        password: '',
+      },
+    }));
   });
 
+  function renderLoginFormContainer() {
+    return render(<LoginFormContainer />);
+  }
+
   it('renders login form', () => {
-    const { getByLabelText, getByText } = render(<LoginFormContainer />);
+    const { getByLabelText, getByText } = renderLoginFormContainer();
 
     expect(getByLabelText('Email')).not.toBeNull();
     expect(getByLabelText('Password')).not.toBeNull();
@@ -26,5 +37,18 @@ describe('LoginFormContainer', () => {
     fireEvent.click(getByText('Log In'));
 
     expect(dispatch).toBeCalled();
+  });
+
+  it('listens to input change events', () => {
+    const { getByLabelText } = renderLoginFormContainer();
+
+    fireEvent.change(getByLabelText('Email'), {
+      target: { value: 'test@test.com' },
+    });
+
+    expect(dispatch).toBeCalledWith({
+      type: 'changeLoginField',
+      payload: { name: 'email', value: 'test@test.com' },
+    });
   });
 });

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -4,6 +4,8 @@ import { render, fireEvent } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
+import given from 'given2';
+
 import LoginFormContainer from './LoginFormContainer';
 
 jest.mock('react-redux');
@@ -17,19 +19,18 @@ describe('LoginFormContainer', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      loginFields: {
-        email: '',
-        password: '',
-      },
+      loginFields: given.loginFields,
     }));
   });
 
-  function renderLoginFormContainer() {
-    return render(<LoginFormContainer />);
-  }
+  given('loginFields', () => ({
+    email: '',
+    password: '',
+    accessToken: '',
+  }));
 
   it('renders login form', () => {
-    const { queryByLabelText, getByText } = renderLoginFormContainer();
+    const { queryByLabelText, getByText } = render(<LoginFormContainer />);
 
     expect(queryByLabelText('Email')).not.toBeNull();
     expect(queryByLabelText('Password')).not.toBeNull();
@@ -40,7 +41,7 @@ describe('LoginFormContainer', () => {
   });
 
   it('listens to input change events', () => {
-    const { getByLabelText } = renderLoginFormContainer();
+    const { getByLabelText } = render(<LoginFormContainer />);
 
     fireEvent.change(getByLabelText('Email'), {
       target: { name: 'email', value: 'test@test.com' },
@@ -49,6 +50,20 @@ describe('LoginFormContainer', () => {
     expect(dispatch).toBeCalledWith({
       type: 'changeLoginField',
       payload: { name: 'email', value: 'test@test.com' },
+    });
+  });
+
+  context('with login', () => {
+    given('loginFields', () => ({
+      email: 'with',
+      password: '',
+      accessToken: 'TOKEN',
+    }));
+
+    it('renders logged on status message', () => {
+      const { container } = render(<LoginFormContainer />);
+
+      expect(container).toHaveTextContent('로그인 되었습니다.');
     });
   });
 });

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -1,14 +1,30 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { useDispatch } from 'react-redux';
 
 import LoginFormContainer from './LoginFormContainer';
 
+jest.mock('react-redux');
+
 describe('LoginFormContainer', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+
+    useDispatch.mockImplemenetation(() => dispatch);
+  });
+
   it('renders login form', () => {
-    const { getByLabelText } = render(<LoginFormContainer />);
+    const { getByLabelText, getByText } = render(<LoginFormContainer />);
 
     expect(getByLabelText('Email')).not.toBeNull();
     expect(getByLabelText('Password')).not.toBeNull();
+
+    fireEvent.click(getByText('Log In'));
+
+    expect(dispatch).toBeCalled();
   });
 });

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -43,7 +43,7 @@ describe('LoginFormContainer', () => {
     const { getByLabelText } = renderLoginFormContainer();
 
     fireEvent.change(getByLabelText('Email'), {
-      target: { value: 'test@test.com' },
+      target: { name: 'email', value: 'test@test.com' },
     });
 
     expect(dispatch).toBeCalledWith({

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -14,51 +14,49 @@ describe('LoginFormContainer', () => {
   const dispatch = jest.fn();
 
   beforeEach(() => {
-    dispatch.mockClear();
+    jest.clearAllMocks();
 
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      loginFields: given.loginFields,
+      accessToken: given.accessToken,
+      loginFields: {
+        email: '',
+        password: '',
+      },
     }));
   });
 
-  given('loginFields', () => ({
-    email: '',
-    password: '',
-    accessToken: '',
-  }));
+  context('without login', () => {
+    given('accessToken', () => '');
 
-  it('renders login form', () => {
-    const { queryByLabelText, getByText } = render(<LoginFormContainer />);
+    it('renders login form', () => {
+      const { queryByLabelText, getByText } = render(<LoginFormContainer />);
 
-    expect(queryByLabelText('Email')).not.toBeNull();
-    expect(queryByLabelText('Password')).not.toBeNull();
+      expect(queryByLabelText('Email')).not.toBeNull();
+      expect(queryByLabelText('Password')).not.toBeNull();
 
-    fireEvent.click(getByText('Log In'));
+      fireEvent.click(getByText('Log In'));
 
-    expect(dispatch).toBeCalled();
-  });
-
-  it('listens to input change events', () => {
-    const { getByLabelText } = render(<LoginFormContainer />);
-
-    fireEvent.change(getByLabelText('Email'), {
-      target: { name: 'email', value: 'test@test.com' },
+      expect(dispatch).toBeCalled();
     });
 
-    expect(dispatch).toBeCalledWith({
-      type: 'changeLoginField',
-      payload: { name: 'email', value: 'test@test.com' },
+    it('listens to input change events', () => {
+      const { getByLabelText } = render(<LoginFormContainer />);
+
+      fireEvent.change(getByLabelText('Email'), {
+        target: { name: 'email', value: 'test@test.com' },
+      });
+
+      expect(dispatch).toBeCalledWith({
+        type: 'changeLoginField',
+        payload: { name: 'email', value: 'test@test.com' },
+      });
     });
   });
 
   context('with login', () => {
-    given('loginFields', () => ({
-      email: 'with',
-      password: '',
-      accessToken: 'TOKEN',
-    }));
+    given('accessToken', () => 'TOKEN');
 
     it('renders logged on status message', () => {
       const { container } = render(<LoginFormContainer />);

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -27,7 +27,7 @@ describe('LoginFormContainer', () => {
     }));
   });
 
-  context('without login', () => {
+  context('when logged out', () => {
     given('accessToken', () => '');
 
     it('renders login form', () => {
@@ -55,13 +55,24 @@ describe('LoginFormContainer', () => {
     });
   });
 
-  context('with login', () => {
+  context('when logged in', () => {
     given('accessToken', () => 'TOKEN');
 
-    it('renders logged on status message', () => {
-      const { container } = render(<LoginFormContainer />);
+    it('renders "Log out" button', () => {
+      const { queryByText } = render(<LoginFormContainer />);
 
-      expect(container).toHaveTextContent('로그인 되었습니다.');
+      expect(queryByText('Log In')).toBeNull();
+      expect(queryByText('Log out')).not.toBeNull();
+    });
+
+    it('logs out when "Log out" is clicked', () => {
+      const { getByText } = render(<LoginFormContainer />);
+
+      fireEvent.click(getByText('Log out'));
+
+      expect(dispatch).toBeCalledWith({
+        type: 'requestLogout',
+      });
     });
   });
 });

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -29,10 +29,10 @@ describe('LoginFormContainer', () => {
   }
 
   it('renders login form', () => {
-    const { getByLabelText, getByText } = renderLoginFormContainer();
+    const { queryByLabelText, getByText } = renderLoginFormContainer();
 
-    expect(getByLabelText('Email')).not.toBeNull();
-    expect(getByLabelText('Password')).not.toBeNull();
+    expect(queryByLabelText('Email')).not.toBeNull();
+    expect(queryByLabelText('Password')).not.toBeNull();
 
     fireEvent.click(getByText('Log In'));
 

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -14,7 +14,7 @@ describe('LoginFormContainer', () => {
   beforeEach(() => {
     dispatch.mockClear();
 
-    useDispatch.mockImplemenetation(() => dispatch);
+    useDispatch.mockImplementation(() => dispatch);
   });
 
   it('renders login form', () => {

--- a/src/LoginFormContainer.test.jsx
+++ b/src/LoginFormContainer.test.jsx
@@ -71,7 +71,8 @@ describe('LoginFormContainer', () => {
       fireEvent.click(getByText('Log out'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'requestLogout',
+        type: 'setAccessToken',
+        payload: { accessToken: '' },
       });
     });
   });

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return (
+    <div>
+      <h2>Log In</h2>
+    </div>
+  );
+}

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 
+import LoginFormContainer from './LoginFormContainer';
+
 export default function LoginPage() {
   return (
     <div>
       <h2>Log In</h2>
+      <LoginFormContainer />
     </div>
   );
 }

--- a/src/LoginPage.test.jsx
+++ b/src/LoginPage.test.jsx
@@ -10,4 +10,11 @@ describe('LoginPage', () => {
 
     expect(container).toHaveTextContent('Log In');
   });
+
+  it('renders login form', () => {
+    const { getByLabelText } = render(<LoginPage />);
+
+    expect(getByLabelText('Email')).not.toBeNull();
+    expect(getByLabelText('Password')).not.toBeNull();
+  });
 });

--- a/src/LoginPage.test.jsx
+++ b/src/LoginPage.test.jsx
@@ -2,9 +2,22 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
+import { useSelector } from 'react-redux';
+
 import LoginPage from './LoginPage';
 
+jest.mock('react-redux');
+
 describe('LoginPage', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      loginFields: {
+        email: '',
+        password: '',
+      },
+    }));
+  });
+
   it('renders "Log In" title', () => {
     const { container } = render(<LoginPage />);
 

--- a/src/LoginPage.test.jsx
+++ b/src/LoginPage.test.jsx
@@ -25,9 +25,9 @@ describe('LoginPage', () => {
   });
 
   it('renders login form', () => {
-    const { getByLabelText } = render(<LoginPage />);
+    const { queryByLabelText } = render(<LoginPage />);
 
-    expect(getByLabelText('Email')).not.toBeNull();
-    expect(getByLabelText('Password')).not.toBeNull();
+    expect(queryByLabelText('Email')).not.toBeNull();
+    expect(queryByLabelText('Password')).not.toBeNull();
   });
 });

--- a/src/LoginPage.test.jsx
+++ b/src/LoginPage.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import LoginPage from './LoginPage';
+
+describe('LoginPage', () => {
+  it('renders "Log In" title', () => {
+    const { container } = render(<LoginPage />);
+
+    expect(container).toHaveTextContent('Log In');
+  });
+});

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -3,9 +3,12 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantDetail from './RestaurantDetail';
+import ReviewForm from './ReviewForm';
 
 import {
   loadRestaurant,
+  changeReviewField,
+  saveReview,
 } from './actions';
 
 import { get } from './utils';
@@ -25,9 +28,24 @@ export default function RestaurantContainer({ restaurantId }) {
     );
   }
 
+  const { score, description } = useSelector(get('reviewFields'));
+
+  function handleChange({ name, value }) {
+    dispatch(changeReviewField({ name, value }));
+  }
+
+  function handleClick() {
+    dispatch(saveReview());
+  }
+
   return (
     <>
       <RestaurantDetail restaurant={restaurant} />
+      <ReviewForm
+        fields={{ score, description }}
+        onChange={handleChange}
+        onClick={handleClick}
+      />
     </>
   );
 }

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -21,6 +21,7 @@ export default function RestaurantContainer({ restaurantId }) {
   }, []);
 
   const restaurant = useSelector(get('restaurant'));
+  const accessToken = useSelector(get('accessToken'));
   const { score, description } = useSelector(get('reviewFields'));
 
   if (!restaurant) {
@@ -40,11 +41,15 @@ export default function RestaurantContainer({ restaurantId }) {
   return (
     <>
       <RestaurantDetail restaurant={restaurant} />
-      <ReviewForm
-        fields={{ score, description }}
-        onChange={handleChange}
-        onClick={handleClick}
-      />
+      { accessToken
+        ? (
+          <ReviewForm
+            fields={{ score, description }}
+            onChange={handleChange}
+            onClick={handleClick}
+          />
+        )
+        : null}
     </>
   );
 }

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantDetail from './RestaurantDetail';
 import ReviewForm from './ReviewForm';
+import RestaurantReviews from './RestaurantReviews';
 
 import {
   loadRestaurant,
@@ -12,39 +13,6 @@ import {
 } from './actions';
 
 import { get } from './utils';
-
-function RestaurantReviews({ restaurant }) {
-  const { reviews } = restaurant;
-
-  return (
-    <>
-      <h3>리뷰</h3>
-      <ul>
-        { reviews.map(({
-          id, name, score, description,
-        }) => (
-          <li key={id}>
-            <p>
-              작성자:
-              {' '}
-              {name}
-            </p>
-            <p>
-              평점:
-              {' '}
-              {score}
-            </p>
-            <p>
-              리뷰 내용:
-              {' '}
-              {description}
-            </p>
-          </li>
-        ))}
-      </ul>
-    </>
-  );
-}
 
 export default function RestaurantContainer({ restaurantId }) {
   const dispatch = useDispatch();

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -13,6 +13,39 @@ import {
 
 import { get } from './utils';
 
+function RestaurantReviews({ restaurant }) {
+  const { reviews } = restaurant;
+
+  return (
+    <>
+      <h3>리뷰</h3>
+      <ul>
+        { reviews.map(({
+          id, name, score, description,
+        }) => (
+          <li key={id}>
+            <p>
+              작성자:
+              {' '}
+              {name}
+            </p>
+            <p>
+              평점:
+              {' '}
+              {score}
+            </p>
+            <p>
+              리뷰 내용:
+              {' '}
+              {description}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
 export default function RestaurantContainer({ restaurantId }) {
   const dispatch = useDispatch();
 
@@ -50,6 +83,7 @@ export default function RestaurantContainer({ restaurantId }) {
           />
         )
         : null}
+      <RestaurantReviews restaurant={restaurant} />
     </>
   );
 }

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -21,14 +21,13 @@ export default function RestaurantContainer({ restaurantId }) {
   }, []);
 
   const restaurant = useSelector(get('restaurant'));
+  const { score, description } = useSelector(get('reviewFields'));
 
   if (!restaurant) {
     return (
       <p>Loading...</p>
     );
   }
-
-  const { score, description } = useSelector(get('reviewFields'));
 
   function handleChange({ name, value }) {
     dispatch(changeReviewField({ name, value }));

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -51,7 +51,7 @@ export default function RestaurantContainer({ restaurantId }) {
           />
         )
         : null}
-      <RestaurantReviews restaurant={restaurant} />
+      <RestaurantReviews reviews={restaurant.reviews} />
     </>
   );
 }

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -20,14 +20,12 @@ describe('RestaurantContainer', () => {
     useSelector.mockImplementation((selector) => selector({
       accessToken: given.accessToken,
       restaurant: given.restaurant,
-      reviewFields: given.reviewFields,
+      reviewFields: {
+        score: '',
+        description: '',
+      },
     }));
   });
-
-  given('reviewFields', () => ({
-    score: '',
-    description: '',
-  }));
 
   it('dispatches action', () => {
     renderRestaurantContainer();
@@ -41,10 +39,6 @@ describe('RestaurantContainer', () => {
       name: '마법사주방',
       address: '서울시 강남구',
     }));
-    given('reviewFields', () => ({
-      score: '',
-      description: '',
-    }));
 
     it('renders name and address', () => {
       const { container } = renderRestaurantContainer();
@@ -55,10 +49,6 @@ describe('RestaurantContainer', () => {
 
     context('when logged in', () => {
       given('accessToken', () => 'TOKEN');
-      given('reviewFields', () => ({
-        score: '',
-        description: '',
-      }));
 
       it('renders review form', () => {
         const { queryByLabelText, queryByText } = renderRestaurantContainer();
@@ -96,14 +86,22 @@ describe('RestaurantContainer', () => {
         expect(dispatch).toBeCalled();
       });
     });
+
+    context('when logged out', () => {
+      given('accessToken', () => '');
+
+      it('does not render review form', () => {
+        const { queryByLabelText, queryByText } = renderRestaurantContainer();
+
+        expect(queryByLabelText('평점')).toBeNull();
+        expect(queryByLabelText('리뷰 내용')).toBeNull();
+        expect(queryByText('리뷰 남기기')).toBeNull();
+      });
+    });
   });
 
   context('without restaurant', () => {
     given('restaurant', () => null);
-    given('reviewFields', () => ({
-      score: '',
-      description: '',
-    }));
 
     it('renders loading', () => {
       const { container } = renderRestaurantContainer();

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -38,6 +38,22 @@ describe('RestaurantContainer', () => {
       id: 1,
       name: '마법사주방',
       address: '서울시 강남구',
+      reviews: [
+        {
+          id: 1,
+          restaurantId: 1,
+          name: '테스터',
+          score: 5,
+          description: '훌륭하다 훌륭하다 지구인놈들',
+        },
+        {
+          id: 3,
+          restaurantId: 1,
+          name: '테스터',
+          score: 3,
+          description: 'Hi!',
+        },
+      ],
     }));
 
     it('renders name and address', () => {
@@ -45,6 +61,12 @@ describe('RestaurantContainer', () => {
 
       expect(container).toHaveTextContent('마법사주방');
       expect(container).toHaveTextContent('서울시');
+    });
+
+    it('renders reviews', () => {
+      const { container } = renderRestaurantContainer();
+
+      expect(container).toHaveTextContent('리뷰');
     });
 
     context('when logged in', () => {

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -24,6 +24,11 @@ describe('RestaurantContainer', () => {
     }));
   });
 
+  given('reviewFields', () => ({
+    score: '',
+    description: '',
+  }));
+
   it('dispatches action', () => {
     renderRestaurantContainer();
 
@@ -95,6 +100,10 @@ describe('RestaurantContainer', () => {
 
   context('without restaurant', () => {
     given('restaurant', () => null);
+    given('reviewFields', () => ({
+      score: '',
+      description: '',
+    }));
 
     it('renders loading', () => {
       const { container } = renderRestaurantContainer();

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -5,7 +5,8 @@ import { useParams } from 'react-router-dom';
 import RestaurantContainer from './RestaurantContainer';
 
 export default function RestaurantPage({ params }) {
-  const { id } = params || useParams();
+  const routerParams = useParams();
+  const { id } = params || routerParams;
 
   return (
     <RestaurantContainer restaurantId={id} />

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -48,7 +48,9 @@ describe('RestaurantPage', () => {
       const params = { id: '1' };
 
       const { container } = render(
-        <RestaurantPage params={params} />,
+        <MemoryRouter>
+          <RestaurantPage params={params} />
+        </MemoryRouter>,
       );
 
       expect(container).toHaveTextContent('마법사주방');

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -19,6 +19,22 @@ describe('RestaurantPage', () => {
         id: 1,
         name: '마법사주방',
         address: '서울시 강남구',
+        reviews: [
+          {
+            id: 1,
+            restaurantId: 1,
+            name: '테스터',
+            score: 5,
+            description: '훌륭하다 훌륭하다 지구인놈들',
+          },
+          {
+            id: 3,
+            restaurantId: 1,
+            name: '테스터',
+            score: 3,
+            description: 'Hi!',
+          },
+        ],
       },
       reviewFields: {
         score: '',

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -20,6 +20,10 @@ describe('RestaurantPage', () => {
         name: '마법사주방',
         address: '서울시 강남구',
       },
+      reviewFields: {
+        score: '',
+        description: '',
+      },
     }));
   });
 

--- a/src/RestaurantReviews.jsx
+++ b/src/RestaurantReviews.jsx
@@ -1,34 +1,44 @@
 import React from 'react';
 
-export default function RestaurantReviews({ restaurant }) {
-  const { reviews } = restaurant;
+function ReviewItems({ reviews }) {
+  if (!(reviews || []).length) {
+    return (
+      <p>등록된 리뷰가 없습니다.</p>
+    );
+  }
 
+  return (
+    <ul>
+      { reviews.map(({
+        id, name, score, description,
+      }) => (
+        <li key={id}>
+          <p>
+            작성자:
+            {' '}
+            {name}
+          </p>
+          <p>
+            평점:
+            {' '}
+            {score}
+          </p>
+          <p>
+            리뷰 내용:
+            {' '}
+            {description}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function RestaurantReviews({ reviews }) {
   return (
     <>
       <h3>리뷰</h3>
-      <ul>
-        { reviews.map(({
-          id, name, score, description,
-        }) => (
-          <li key={id}>
-            <p>
-              작성자:
-              {' '}
-              {name}
-            </p>
-            <p>
-              평점:
-              {' '}
-              {score}
-            </p>
-            <p>
-              리뷰 내용:
-              {' '}
-              {description}
-            </p>
-          </li>
-        ))}
-      </ul>
+      <ReviewItems reviews={reviews} />
     </>
   );
 }

--- a/src/RestaurantReviews.jsx
+++ b/src/RestaurantReviews.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default function RestaurantReviews({ restaurant }) {
+  const { reviews } = restaurant;
+
+  return (
+    <>
+      <h3>리뷰</h3>
+      <ul>
+        { reviews.map(({
+          id, name, score, description,
+        }) => (
+          <li key={id}>
+            <p>
+              작성자:
+              {' '}
+              {name}
+            </p>
+            <p>
+              평점:
+              {' '}
+              {score}
+            </p>
+            <p>
+              리뷰 내용:
+              {' '}
+              {description}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/RestaurantReviews.jsx
+++ b/src/RestaurantReviews.jsx
@@ -1,38 +1,6 @@
 import React from 'react';
 
-function ReviewItems({ reviews }) {
-  if (!(reviews || []).length) {
-    return (
-      <p>등록된 리뷰가 없습니다.</p>
-    );
-  }
-
-  return (
-    <ul>
-      { reviews.map(({
-        id, name, score, description,
-      }) => (
-        <li key={id}>
-          <p>
-            작성자:
-            {' '}
-            {name}
-          </p>
-          <p>
-            평점:
-            {' '}
-            {score}
-          </p>
-          <p>
-            리뷰 내용:
-            {' '}
-            {description}
-          </p>
-        </li>
-      ))}
-    </ul>
-  );
-}
+import ReviewItems from './ReviewItems';
 
 export default function RestaurantReviews({ reviews }) {
   return (

--- a/src/RestaurantReviews.test.jsx
+++ b/src/RestaurantReviews.test.jsx
@@ -5,11 +5,8 @@ import { render } from '@testing-library/react';
 import RestaurantReviews from './RestaurantReviews';
 
 describe('RestaurantReviews', () => {
-  const restaurant = {
-    id: 1,
-    name: '마녀주방',
-    address: '서울시 강남구',
-    reviews: [
+  context('with reviews', () => {
+    const reviews = [
       {
         id: 1,
         restaurantId: 1,
@@ -17,26 +14,33 @@ describe('RestaurantReviews', () => {
         score: 5,
         description: '훌륭하다 훌륭하다 지구인놈들',
       },
-      {
-        id: 3,
-        restaurantId: 1,
-        name: '테스터',
-        score: 3,
-        description: 'Hi!',
-      },
-    ],
-  };
+    ];
 
-  it('renders reviews', () => {
-    const { container } = render((
-      <RestaurantReviews
-        restaurant={restaurant}
-      />
-    ));
+    it('renders reviews', () => {
+      const { container } = render((
+        <RestaurantReviews
+          reviews={reviews}
+        />
+      ));
 
-    expect(container).toHaveTextContent('리뷰');
-    expect(container).toHaveTextContent('작성자');
-    expect(container).toHaveTextContent('평점');
-    expect(container).toHaveTextContent('리뷰 내용');
+      expect(container).toHaveTextContent('리뷰');
+      expect(container).toHaveTextContent('작성자');
+      expect(container).toHaveTextContent('평점');
+      expect(container).toHaveTextContent('리뷰 내용');
+    });
+  });
+
+  context('without reviews', () => {
+    it('renders no reviews message', () => {
+      [[], undefined, null].forEach((reviews) => {
+        const { container } = render((
+          <RestaurantReviews
+            reviews={reviews}
+          />
+        ));
+
+        expect(container).toHaveTextContent('등록된 리뷰가 없습니다.');
+      });
+    });
   });
 });

--- a/src/RestaurantReviews.test.jsx
+++ b/src/RestaurantReviews.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import RestaurantReviews from './RestaurantReviews';
+
+describe('RestaurantReviews', () => {
+  const restaurant = {
+    id: 1,
+    name: '마녀주방',
+    address: '서울시 강남구',
+    reviews: [
+      {
+        id: 1,
+        restaurantId: 1,
+        name: '테스터',
+        score: 5,
+        description: '훌륭하다 훌륭하다 지구인놈들',
+      },
+      {
+        id: 3,
+        restaurantId: 1,
+        name: '테스터',
+        score: 3,
+        description: 'Hi!',
+      },
+    ],
+  };
+
+  it('renders reviews', () => {
+    const { container } = render((
+      <RestaurantReviews
+        restaurant={restaurant}
+      />
+    ));
+
+    expect(container).toHaveTextContent('리뷰');
+    expect(container).toHaveTextContent('작성자');
+    expect(container).toHaveTextContent('평점');
+    expect(container).toHaveTextContent('리뷰 내용');
+  });
+});

--- a/src/ReviewForm.jsx
+++ b/src/ReviewForm.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import InputField from './InputField';
+
+export default function ReviewForm({ fields, onChange, onClick }) {
+  const { score, description } = fields;
+
+  return (
+    <>
+      <InputField
+        label="평점"
+        type="number"
+        name="score"
+        value={score}
+        onChange={onChange}
+      />
+      <InputField
+        label="리뷰 내용"
+        type="text"
+        name="description"
+        value={description}
+        onChange={onChange}
+      />
+      <button
+        type="button"
+        onClick={onClick}
+      >
+        리뷰 남기기
+      </button>
+    </>
+  );
+}

--- a/src/ReviewForm.test.jsx
+++ b/src/ReviewForm.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import ReviewForm from './ReviewForm';
+
+describe('ReviewForm', () => {
+  const handleChange = jest.fn();
+  const handleClick = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+    handleClick.mockClear();
+  });
+
+  function renderReviewForm({ score, description }) {
+    return render((
+      <ReviewForm
+        fields={{ score, description }}
+        onChange={handleChange}
+        onClick={handleClick}
+      />
+    ));
+  }
+
+  it('renders review form', () => {
+    const { queryByLabelText, getByText } = renderReviewForm({});
+
+    expect(queryByLabelText('평점')).not.toBeNull();
+    expect(queryByLabelText('리뷰 내용')).not.toBeNull();
+
+    fireEvent.click(getByText('리뷰 남기기'));
+
+    expect(handleClick).toBeCalled();
+  });
+
+  it('listens to input change events', () => {
+    const controls = [
+      {
+        label: '평점',
+        name: 'number',
+        origin: '',
+        value: '5',
+      },
+      {
+        label: '리뷰 내용',
+        name: 'description',
+        origin: '',
+        value: '돈쭐맛집',
+      },
+    ];
+    const { getByLabelText } = renderReviewForm({ email: '', password: '' });
+
+    controls.forEach(({
+      label, name, origin, value,
+    }) => {
+      expect(getByLabelText(label).value).toBe(origin);
+
+      fireEvent.change(getByLabelText(label), {
+        target: { name, value },
+      });
+
+      expect(handleChange).toBeCalledWith({ name, value });
+    });
+  });
+});

--- a/src/ReviewForm.test.jsx
+++ b/src/ReviewForm.test.jsx
@@ -49,7 +49,7 @@ describe('ReviewForm', () => {
         value: '돈쭐맛집',
       },
     ];
-    const { getByLabelText } = renderReviewForm({ email: '', password: '' });
+    const { getByLabelText } = renderReviewForm({ score: '', description: '' });
 
     controls.forEach(({
       label, name, origin, value,

--- a/src/ReviewItems.jsx
+++ b/src/ReviewItems.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export default function ReviewItems({ reviews }) {
+  if (!(reviews || []).length) {
+    return (
+      <p>등록된 리뷰가 없습니다.</p>
+    );
+  }
+
+  return (
+    <ul>
+      { reviews.map(({
+        id, name, score, description,
+      }) => (
+        <li key={id}>
+          <p>
+            작성자:
+            {' '}
+            {name}
+          </p>
+          <p>
+            평점:
+            {' '}
+            {score}
+          </p>
+          <p>
+            리뷰 내용:
+            {' '}
+            {description}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/ReviewItems.test.jsx
+++ b/src/ReviewItems.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import ReviewItems from './ReviewItems';
+
+describe('ReviewItems', () => {
+  context('with review items', () => {
+    it('renders review items', () => {
+      const reviews = [
+        {
+          id: 1,
+          restaurantId: 1,
+          name: '테스터',
+          score: 5,
+          description: '훌륭하다 훌륭하다 지구인놈들',
+        },
+      ];
+
+      const { container } = render(<ReviewItems reviews={reviews} />);
+
+      expect(container).toHaveTextContent('훌륭하다');
+    });
+  });
+
+  context('without menu item', () => {
+    it('renders no items message', () => {
+      [[], null, undefined].forEach((reviews) => {
+        const { container } = render(<ReviewItems reviews={reviews} />);
+
+        expect(container).toHaveTextContent('등록된 리뷰가 없습니다');
+      });
+    });
+  });
+});

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,6 +3,7 @@ import {
   fetchCategories,
   fetchRestaurants,
   fetchRestaurant,
+  postLogin,
 } from './services/api';
 
 export function setRegions(regions) {
@@ -30,6 +31,13 @@ export function setRestaurant(restaurant) {
   return {
     type: 'setRestaurant',
     payload: { restaurant },
+  };
+}
+
+export function setAccessToken(accesesToken) {
+  return {
+    type: 'setAccesesToken',
+    payload: { accesesToken },
   };
 }
 
@@ -94,10 +102,11 @@ export function changeLoginField({ name, value }) {
 }
 
 export function requestLogin() {
-  /*
-   TODO
-   - get { email, password}
-   - get access token by posting login
-   - set access token
-   */
+  return async (dispatch, getState) => {
+    const { loginFields: { email, password } } = getState();
+
+    const accessToken = await postLogin({ email, password });
+
+    dispatch(setAccessToken(accessToken));
+  };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -34,10 +34,10 @@ export function setRestaurant(restaurant) {
   };
 }
 
-export function setAccessToken(accesesToken) {
+export function setAccessToken(accessToken) {
   return {
-    type: 'setAccesesToken',
-    payload: { accesesToken },
+    type: 'setAccessToken',
+    payload: { accessToken },
   };
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -86,6 +86,13 @@ export function loadRestaurant({ restaurantId }) {
   };
 }
 
+export function changeLoginField({ name, value }) {
+  return {
+    type: 'changeLoginField',
+    payload: { name, value },
+  };
+}
+
 export function requestLogin() {
   /*
    TODO

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,6 +7,10 @@ import {
   postReview,
 } from './services/api';
 
+import {
+  saveItem,
+} from './services/storage';
+
 export function setRegions(regions) {
   return {
     type: 'setRegions',
@@ -114,6 +118,8 @@ export function requestLogin() {
     const { loginFields: { email, password } } = getState();
 
     const { accessToken } = await postLogin({ email, password });
+
+    saveItem('accessToken', accessToken);
 
     dispatch(setAccessToken(accessToken));
   };

--- a/src/actions.js
+++ b/src/actions.js
@@ -110,3 +110,9 @@ export function requestLogin() {
     dispatch(setAccessToken(accessToken));
   };
 }
+
+export function requestLogout() {
+  return {
+    type: 'requestLogout',
+  };
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -85,3 +85,12 @@ export function loadRestaurant({ restaurantId }) {
     dispatch(setRestaurant(restaurant));
   };
 }
+
+export function requestLogin() {
+  /*
+   TODO
+   - get { email, password}
+   - get access token by posting login
+   - set access token
+   */
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -113,7 +113,7 @@ export function requestLogin() {
   return async (dispatch, getState) => {
     const { loginFields: { email, password } } = getState();
 
-    const accessToken = await postLogin({ email, password });
+    const { accessToken } = await postLogin({ email, password });
 
     dispatch(setAccessToken(accessToken));
   };

--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,7 @@ import {
   fetchRestaurants,
   fetchRestaurant,
   postLogin,
+  postReview,
 } from './services/api';
 
 export function setRegions(regions) {
@@ -119,5 +120,15 @@ export function requestLogin() {
 }
 
 export function saveReview() {
-  // TODO: post review
+  return async (dispatch, getState) => {
+    const { accessToken } = getState();
+    const { restaurant: { id: restaurantId } } = getState();
+    const { reviewFields: { score, description } } = getState();
+
+    await postReview({
+      accessToken, restaurantId, score, description,
+    });
+
+    dispatch(loadRestaurant({ restaurantId }));
+  };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -101,6 +101,13 @@ export function changeLoginField({ name, value }) {
   };
 }
 
+export function changeReviewField({ name, value }) {
+  return {
+    type: 'changeReviewField',
+    payload: { name, value },
+  };
+}
+
 export function requestLogin() {
   return async (dispatch, getState) => {
     const { loginFields: { email, password } } = getState();
@@ -109,4 +116,8 @@ export function requestLogin() {
 
     dispatch(setAccessToken(accessToken));
   };
+}
+
+export function saveReview() {
+  // TODO: post review
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -110,9 +110,3 @@ export function requestLogin() {
     dispatch(setAccessToken(accessToken));
   };
 }
-
-export function requestLogout() {
-  return {
-    type: 'requestLogout',
-  };
-}

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -94,7 +94,7 @@ describe('actions', () => {
       store = mockStore({});
     });
 
-    it('dispatchs setRestaurant', async () => {
+    it('dispatches setRestaurant', async () => {
       await store.dispatch(loadRestaurant({ restaurantId: 1 }));
 
       const actions = store.getActions();
@@ -111,7 +111,7 @@ describe('actions', () => {
       });
     });
 
-    it('dispatchs setAccessToken', async () => {
+    it('dispatches setAccessToken', async () => {
       await store.dispatch(requestLogin());
 
       const actions = store.getActions();
@@ -128,7 +128,7 @@ describe('actions', () => {
       });
     });
 
-    it('dispatchs setRestaurant', async () => {
+    it('dispatches setRestaurant', async () => {
       await store.dispatch(saveReview());
 
       const actions = store.getActions();

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -12,6 +12,7 @@ import {
   setRestaurant,
   requestLogin,
   setAccessToken,
+  saveReview,
 } from './actions';
 
 const middlewares = [thunk];
@@ -116,6 +117,24 @@ describe('actions', () => {
       const actions = store.getActions();
 
       expect(actions[0]).toEqual(setAccessToken({}));
+    });
+  });
+
+  describe('saveReview', () => {
+    beforeEach(() => {
+      store = mockStore({
+        restaurant: { id: 1, name: '양천주가' },
+        reviewFields: { score: '5', description: '돈쭐맛집' },
+      });
+    });
+
+    it('dispatchs setRestaurant', async () => {
+      await store.dispatch(saveReview());
+
+      const actions = store.getActions();
+
+      expect(actions[0]).toEqual(setRestaurant(null));
+      expect(actions[1]).toEqual(setRestaurant({}));
     });
   });
 });

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -105,7 +105,9 @@ describe('actions', () => {
 
   describe('requestLogin', () => {
     beforeEach(() => {
-      store = mockStore({});
+      store = mockStore({
+        loginFields: { email: 'test@test.com', password: 'test' },
+      });
     });
 
     it('dispatchs setAccessToken', async () => {
@@ -113,8 +115,7 @@ describe('actions', () => {
 
       const actions = store.getActions();
 
-      expect(actions[0]).toEqual(setAccessToken(null));
-      expect(actions[1]).toEqual(setAccessToken({}));
+      expect(actions[0]).toEqual(setAccessToken({}));
     });
   });
 });

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -116,7 +116,7 @@ describe('actions', () => {
 
       const actions = store.getActions();
 
-      expect(actions[0]).toEqual(setAccessToken({}));
+      expect(actions[0]).toEqual(setAccessToken(''));
     });
   });
 

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -10,6 +10,8 @@ import {
   loadRestaurant,
   setRestaurants,
   setRestaurant,
+  requestLogin,
+  setAccessToken,
 } from './actions';
 
 const middlewares = [thunk];
@@ -98,6 +100,21 @@ describe('actions', () => {
 
       expect(actions[0]).toEqual(setRestaurant(null));
       expect(actions[1]).toEqual(setRestaurant({}));
+    });
+  });
+
+  describe('requestLogin', () => {
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    it('dispatchs setAccessToken', async () => {
+      await store.dispatch(requestLogin());
+
+      const actions = store.getActions();
+
+      expect(actions[0]).toEqual(setAccessToken(null));
+      expect(actions[1]).toEqual(setAccessToken({}));
     });
   });
 });

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -19,6 +19,7 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 jest.mock('./services/api');
+jest.mock('./services/storage');
 
 describe('actions', () => {
   let store;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,6 +7,10 @@ const initialState = {
   restaurant: null,
   selectedRegion: null,
   selectedCategory: null,
+  loginFields: {
+    email: '',
+    password: '',
+  },
 };
 
 const reducers = {
@@ -51,6 +55,17 @@ const reducers = {
     return {
       ...state,
       selectedCategory: categories.find(equal('id', categoryId)),
+    };
+  },
+
+  changeLoginField(state, { payload: { name, value } }) {
+    const { loginFields } = state;
+    return {
+      ...state,
+      loginFields: {
+        ...loginFields,
+        [name]: value,
+      },
     };
   },
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -12,6 +12,10 @@ const initialState = {
     email: '',
     password: '',
   },
+  reviewFields: {
+    score: '',
+    description: '',
+  },
 };
 
 const reducers = {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,6 +1,7 @@
 import { equal } from './utils';
 
 const initialState = {
+  accessToken: '',
   regions: [],
   categories: [],
   restaurants: [],
@@ -39,6 +40,13 @@ const reducers = {
     return {
       ...state,
       restaurant,
+    };
+  },
+
+  setAccessToken(state, { payload: { accessToken } }) {
+    return {
+      ...state,
+      accessToken,
     };
   },
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -80,6 +80,17 @@ const reducers = {
       },
     };
   },
+
+  changeReviewField(state, { payload: { name, value } }) {
+    const { reviewFields } = state;
+    return {
+      ...state,
+      reviewFields: {
+        ...reviewFields,
+        [name]: value,
+      },
+    };
+  },
 };
 
 function defaultReducer(state) {

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -132,39 +132,25 @@ describe('reducer', () => {
   });
 
   describe('changeLoginField', () => {
-    context('when email field changes', () => {
-      it('changes login field', () => {
+    it('changes login field', () => {
+      const fields = [
+        { name: 'email', origin: '', value: 'test@test.com' },
+        { name: 'password', origin: '', value: 'test' },
+      ];
+
+      fields.forEach(({ name, origin, value }) => {
         const initialState = {
           loginFields: {
-            email: '',
-            password: '',
+            [name]: origin,
           },
         };
 
         const state = reducer(
           initialState,
-          changeLoginField({ name: 'email', value: 'test@test.com' }),
+          changeLoginField({ name, value }),
         );
 
-        expect(state.loginFields.email).toBe('test@test.com');
-      });
-    });
-
-    context('when password field changes', () => {
-      it('changes login field', () => {
-        const initialState = {
-          loginFields: {
-            email: '',
-            password: '',
-          },
-        };
-
-        const state = reducer(
-          initialState,
-          changeLoginField({ name: 'password', value: 'test' }),
-        );
-
-        expect(state.loginFields.password).toBe('test');
+        expect(state.loginFields[name]).toBe(value);
       });
     });
   });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -8,6 +8,7 @@ import {
   selectRegion,
   selectCategory,
   changeLoginField,
+  setAccessToken,
 } from './actions';
 
 describe('reducer', () => {
@@ -152,6 +153,20 @@ describe('reducer', () => {
 
         expect(state.loginFields[name]).toBe(value);
       });
+    });
+  });
+
+  describe('setAccessToken', () => {
+    it('changes access token', () => {
+      const initialState = {
+        accessToken: '',
+      };
+
+      const accessToken = 'TOKEN';
+
+      const state = reducer(initialState, setAccessToken(accessToken));
+
+      expect(state.accessToken).toBe(accessToken);
     });
   });
 });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -25,6 +25,10 @@ describe('reducer', () => {
         email: '',
         password: '',
       },
+      reviewFields: {
+        score: '',
+        description: '',
+      },
     };
 
     it('returns initialState', () => {

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -19,6 +19,10 @@ describe('reducer', () => {
       restaurant: null,
       selectedRegion: null,
       selectedCategory: null,
+      loginFields: {
+        email: '',
+        password: '',
+      },
     };
 
     it('returns initialState', () => {
@@ -137,9 +141,30 @@ describe('reducer', () => {
           },
         };
 
-        const state = reducer(initialState, changeLoginField({ name: 'email', value: 'test@test.com' }));
+        const state = reducer(
+          initialState,
+          changeLoginField({ name: 'email', value: 'test@test.com' }),
+        );
 
         expect(state.loginFields.email).toBe('test@test.com');
+      });
+    });
+
+    context('when password field changes', () => {
+      it('changes login field', () => {
+        const initialState = {
+          loginFields: {
+            email: '',
+            password: '',
+          },
+        };
+
+        const state = reducer(
+          initialState,
+          changeLoginField({ name: 'password', value: 'test' }),
+        );
+
+        expect(state.loginFields.password).toBe('test');
       });
     });
   });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -7,6 +7,7 @@ import {
   setRestaurant,
   selectRegion,
   selectCategory,
+  changeLoginField,
 } from './actions';
 
 describe('reducer', () => {
@@ -122,6 +123,23 @@ describe('reducer', () => {
       expect(state.selectedCategory).toEqual({
         id: 1,
         name: '한식',
+      });
+    });
+  });
+
+  describe('changeLoginField', () => {
+    context('when email field changes', () => {
+      it('changes login field', () => {
+        const initialState = {
+          loginFields: {
+            email: '',
+            password: '',
+          },
+        };
+
+        const state = reducer(initialState, changeLoginField({ name: 'email', value: 'test@test.com' }));
+
+        expect(state.loginFields.email).toBe('test@test.com');
       });
     });
   });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -14,6 +14,7 @@ import {
 describe('reducer', () => {
   context('when previous state is undefined', () => {
     const initialState = {
+      accessToken: '',
       regions: [],
       categories: [],
       restaurants: [],

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -8,6 +8,7 @@ import {
   selectRegion,
   selectCategory,
   changeLoginField,
+  changeReviewField,
   setAccessToken,
 } from './actions';
 
@@ -157,6 +158,30 @@ describe('reducer', () => {
         );
 
         expect(state.loginFields[name]).toBe(value);
+      });
+    });
+  });
+
+  describe('changeReviewField', () => {
+    it('changes review field', () => {
+      const fields = [
+        { name: 'score', origin: '', value: '5' },
+        { name: 'description', origin: '', value: '돈쭐맛집' },
+      ];
+
+      fields.forEach(({ name, origin, value }) => {
+        const initialState = {
+          reviewFields: {
+            [name]: origin,
+          },
+        };
+
+        const state = reducer(
+          initialState,
+          changeReviewField({ name, value }),
+        );
+
+        expect(state.reviewFields[name]).toBe(value);
       });
     });
   });

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -13,3 +13,7 @@ export async function fetchRestaurants() {
 export async function fetchRestaurant() {
   return {};
 }
+
+export async function postLogin() {
+  return {};
+}

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -17,3 +17,7 @@ export async function fetchRestaurant() {
 export async function postLogin() {
   return {};
 }
+
+export async function postReview() {
+  return {};
+}

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -15,7 +15,9 @@ export async function fetchRestaurant() {
 }
 
 export async function postLogin() {
-  return {};
+  return {
+    accessToken: '',
+  };
 }
 
 export async function postReview() {

--- a/src/services/__mocks__/storage.js
+++ b/src/services/__mocks__/storage.js
@@ -1,0 +1,3 @@
+export const saveItem = jest.fn();
+
+export const loadItem = jest.fn();

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -27,3 +27,16 @@ export async function fetchRestaurant({ restaurantId }) {
   const data = await response.json();
   return data;
 }
+
+export async function postLogin({ email, password }) {
+  const url = 'https://eatgo-login-api.ahastudio.com/sessions';
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+  const data = await response.json();
+  return data;
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -40,3 +40,20 @@ export async function postLogin({ email, password }) {
   const data = await response.json();
   return data;
 }
+
+export async function postReview({
+  accessToken, restaurantId, score, description,
+}) {
+  const url = 'https://eatgo-customer-api.ahastudio.com/restaurants'
+  + `?restaurantId=${restaurantId}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ score, description }),
+  });
+  const data = await response.json();
+  return data;
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -29,7 +29,7 @@ export async function fetchRestaurant({ restaurantId }) {
 }
 
 export async function postLogin({ email, password }) {
-  const url = 'https://eatgo-login-api.ahastudio.com/sessions';
+  const url = 'https://eatgo-login-api.ahastudio.com/session';
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -44,8 +44,8 @@ export async function postLogin({ email, password }) {
 export async function postReview({
   accessToken, restaurantId, score, description,
 }) {
-  const url = 'https://eatgo-customer-api.ahastudio.com/restaurants'
-  + `?restaurantId=${restaurantId}`;
+  const url = 'https://eatgo-customer-api.ahastudio.com'
+  + `/restaurants/${restaurantId}/reviews`;
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -84,4 +84,20 @@ describe('api', () => {
       expect(accessToken).toEqual(ACCESSTOKEN);
     });
   });
+
+  describe('saveReview', () => {
+    beforeEach(() => {
+      mockFetch('');
+    });
+
+    // TODO: 리뷰 저장 API가 어떤 응답 주는지 확인해야 함
+    // it('returns access token', async () => {
+    //   const accessToken = await postLogin({
+    //     email: 'test@test.com',
+    //     password: 'test',
+    //   });
+
+    //   expect(accessToken).toEqual(ACCESSTOKEN);
+    // });
+  });
 });

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -3,12 +3,14 @@ import {
   fetchCategories,
   fetchRestaurants,
   fetchRestaurant,
+  postLogin,
 } from './api';
 
 import REGIONS from '../../fixtures/regions';
 import CATEGORIES from '../../fixtures/categories';
 import RESTAURANTS from '../../fixtures/restaurants';
 import RESTAURANT from '../../fixtures/restaurant';
+import ACCESSTOKEN from '../../fixtures/accessToken';
 
 describe('api', () => {
   const mockFetch = (data) => {
@@ -65,6 +67,21 @@ describe('api', () => {
       const restaurant = await fetchRestaurant({ restaurantId: 1 });
 
       expect(restaurant).toEqual(RESTAURANT);
+    });
+  });
+
+  describe('postLogin', () => {
+    beforeEach(() => {
+      mockFetch(ACCESSTOKEN);
+    });
+
+    it('returns access token', async () => {
+      const accessToken = await postLogin({
+        email: 'test@test.com',
+        password: 'test',
+      });
+
+      expect(accessToken).toEqual(ACCESSTOKEN);
     });
   });
 });

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -4,6 +4,7 @@ import {
   fetchRestaurants,
   fetchRestaurant,
   postLogin,
+  postReview,
 } from './api';
 
 import REGIONS from '../../fixtures/regions';
@@ -87,17 +88,18 @@ describe('api', () => {
 
   describe('saveReview', () => {
     beforeEach(() => {
-      mockFetch('');
+      mockFetch({});
     });
 
-    // TODO: 리뷰 저장 API가 어떤 응답 주는지 확인해야 함
-    // it('returns access token', async () => {
-    //   const accessToken = await postLogin({
-    //     email: 'test@test.com',
-    //     password: 'test',
-    //   });
+    it('returns empty object', async () => {
+      const data = await postReview({
+        accessToken: 'TOKEN',
+        restaurantId: 1,
+        score: '5',
+        description: '돈쭐맛집',
+      });
 
-    //   expect(accessToken).toEqual(ACCESSTOKEN);
-    // });
+      expect(data).toEqual({});
+    });
   });
 });

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,0 +1,7 @@
+export function saveItem(key, value) {
+  localStorage.setItem(key, value);
+}
+
+export function loadItem(key) {
+  localStorage.getItem(key);
+}

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -3,5 +3,5 @@ export function saveItem(key, value) {
 }
 
 export function loadItem(key) {
-  localStorage.getItem(key);
+  return localStorage.getItem(key);
 }

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -1,0 +1,33 @@
+import {
+  loadItem,
+  saveItem,
+} from './storage';
+
+describe('storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('loadItem', () => {
+    beforeEach(() => {
+      localStorage.setItem('accessToken', 'TOKEN');
+    });
+
+    it('loads item', () => {
+      const item = loadItem('accessToken');
+
+      expect(item).toBe('TOKEN');
+    });
+  });
+
+  describe('saveItem', () => {
+    it('loads item', () => {
+      saveItem('accessToken', 'TOKEN');
+
+      const item = loadItem('accessToken');
+
+      expect(item).toBe('TOKEN');
+    });
+  });
+});


### PR DESCRIPTION
7주차 과제 제출합니다.

## 진행상황

### 2021.03.08(월)

* 로그인 페이지 라우팅을 TDD로 구현
* 로그인 화면 TDD로 구현
* 로그인 필드가 input change 이벤트를 리스닝하도록 TDD로 구현
* 리듀서에서 로그인 필드를 변경하도록 TDD로 구현

### 2021.03.09(화)

* 로그인 세션 access token 얻어오기
* [메타인지] 리뷰 모음 및 알게 된 것 정리

### 2021.03.10(수)

* [메타인지] 리뷰 모음 및 알게 된 것 정리
* 로그인 폼 UI를 TDD로 구현
* 로그인 상태에 따른 로그인폼 컨테이너를 TDD로 구현
* 리뷰 폼을 TDD로 구현
* 리뷰 저장 비동기 액션을 TDD로 구현

### 2021.03.11(목)

* 리뷰 저장 기능을 TDD로 구현
* 리액트 훅을 동일한 순서로 실행되도록 변경
* 로컬 스토리지를 사용해서 자동 로그인을 TDD로 구현
* 로그인 상태에 따라 리뷰 폼을 조건부 렌더링하도록 TDD로 구현
* 리뷰 목록을 렌더링하도록 TDD로 구현

### 2021.03.12(금)

* [메타인지] 리뷰 모음 및 알게 된 것 정리
* `storage` 테스트 코드 작성
* 리액트 훅 `useParams`를 항상 동일한 순서로 실행되도록 변경
* 테스트에서 불필요한 mock 데이터 삭제
* 레스토랑 리뷰 컴포넌트 분리
* 리뷰가 없는 상황에 대한 처리
* 리뷰 아이템 컴포넌트 분리

### 2021.03.14(일)

* 테스트 코드 오타 수정

## TODO

* `localStorage`를 jest에서 manual mock으로 처리하는 방법 알아보기
* API 응답 실패에 따른 예외 처리하기
  * try-catch 사용하기
  * 에러 발생하면 UI에서 어떻게 대응할지 생각하기
* 리뷰 남긴 후에 남긴 리뷰를 바로 볼 수 있도록 리뷰 목록을 최신 순서로 정렬하기
* 리뷰를 남기면 레스토랑 상세 페이지 전체가 리렌더링 되는 게 아니라 리뷰 영역만 리렌더링 되게 만들기

## 궁금한 점

## 코드 리뷰 모음

* [변수 네이밍] 이 경우에는 복수로 fields 가 더 적합하겠죠? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589404618)
* [관심사 분리] 2개 뿐이긴 하지만 현재 구조에서 Field 같은 컴포넌트로 리팩터링 해보면 좋을 것 같아요! - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589407130)
* [이벤트 핸들러 테스트] 테스트와 구현부가 동일한가요? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589411986)
* [화면 UI에서 이벤트 핸들러 테스트] toBeCalledWith 을 사용하면 더 명확하게 테스트를 이해할 수 있을 것 같아요. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589412598)
* [테스트] queryBy~ 와 getBy~ 의 차이점을 알고 있으신가요? :) 테스트에서 toBeNull() 로 확인한다고 할 때 어떤게 더 적합한 것 같나요? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589417808) 
* [테스트 관심사] 저는 reducer 입장에서는 각각 email 과 password 필드가 바뀌는 게 차이가 있을까 생각이 드는데 어떻게 생각하시나요? 🤔 (자유롭게 의견 말씀해주시면 좋을 것 같아요.) changeLoginField 의 name 과 value 값만 변하는 거긴 해서 만약 필드가 여러개 라면 어떻게 될까요? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589422292)
* [???] field 도 추상화 형태를 맞춰주는게 어떨까요? 굳이 매개변수를 destructuring 해주지 않아도 될 것 같아요. 실제로 email 과 password 가 들어간다는 건 아래에서 render 함수를 사용할 때 드러나기 때문이에요. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589410573)
* [가독성] 컴포넌트는 기본적으로 () 로 감싸주시면 좋아요. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r590638076)
* [테스트] 로그인은 with, without 보다는 when 으로 묘사하는게 낫지 않을까요? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r590639429)
* [테스트] 해당 내용들이 미리 입력되어 있어야하는 이유가 있나요? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r592452623)
* [예외 처리] reviews 가 없는 경우 어떻게 될까요? - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r592456151)
* [리액트 훅] 선언 순서에 따른 에러를 겪었다고 하셔서 참고로 말씀 드리면 저는 useDispatch - useSelector - useEffect - functions - return elements 순으로 정렬해주는 편이에요. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r592458678)

## 메타인지

### 내가 모르는 것은 무엇인가

* 문자열 값을 가지는 `accessToken`의 초기값을 빈 문자열과 null 중 어떤 것으로 하는 게 나은가?
* `jest-localstorage-mock` 라이브러리를 사용하지 않고 jest의 manual mock으로 local storage를 모킹하고 싶은데 되지 않는다. 왜 안되는 건지 모르겠다.

### 내가 알게 된 것은 무엇인가

* `queryBy~`와 `getBy~`의 차이점과 각각 언제 사용하면 적절한가 - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589876471)
* 화면 UI를 테스트할 때 이벤트 핸들러에 파라미터가 있으면 `toBeCalledWith()`를 사용하면 테스트 의도가 더 명확하게 드러난다. [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r589412598)
* 구조분해할당이 복잡해지면 라인을 분리해서 해준다. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r590635492)
* 컴포넌트는 기본적으로 () 로 감싸주시면 좋다. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r590638076)
* 로그인은 with, without 보다는 when 으로 묘사하는게 낫다. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r590639429)
* early return 이후 리액트 훅을 호출하는 코드가 있으면 에러가 난다. 리액트 훅은 항상 동일한 순서로 실행되어야 하기 때문이다. - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#issuecomment-796552799)
* `jest-localstorage-mock` 라이브러리를 사용해서 `storage.js`를 테스트하는 방법
* 리액트 훅 선언 순서에 따른 에러를 겪지 않는 패턴 중 하나: `useDispatch` - `useSelector` - `useEffect` - `functions` - `return elements` - [comment](https://github.com/CodeSoom/react-week7-assignment-1/pull/38#discussion_r592458678)
* `reviews`가 `null`, `undefined`, `[]`일 때 한 번에 처리하는 방법 

```jsx
if (!(reviews || []).length) {
  return (
    <p>등록된 리뷰가 없습니다.</p>
  );
}
```


### 어떻게 하면 더 나을까

과제 주차는 끝났지만, 풀이 영상을 보면서 다음에는 이걸 더 하면 좋겠다, 싶은 내용을 적습니다.

* API 응답 실패에 따른 예외 처리하기
  * try-catch 사용하기
  * 에러 발생하면 UI에서 어떻게 대응할지 생각하기
* 리뷰 남긴 후에 남긴 리뷰를 바로 볼 수 있도록 리뷰 목록을 최신 순서로 정렬하기
* 리뷰를 남기면 레스토랑 상세 페이지 전체가 리렌더링 되는 게 아니라 리뷰 영역만 리렌더링 되게 만들기


## 읽은 글

## 주간회고

[7주차 주간 회고](https://www.notion.so/jayday/7-966430bf79fc4acf8b69ceb84d208745)